### PR TITLE
Ignoring compile-time warning

### DIFF
--- a/app/src/main/java/com/example/woof/MainActivity.kt
+++ b/app/src/main/java/com/example/woof/MainActivity.kt
@@ -181,6 +181,7 @@ private fun DogItemButton(
  *
  * @param modifier modifiers to set to this composable
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WoofTopAppBar(modifier: Modifier = Modifier) {
     CenterAlignedTopAppBar(


### PR DESCRIPTION
Added annotation `@OptIn(ExperimentalMaterial3Api::class)` to ignore compile-time warning.