### PR TITLE
Fix: Apply theme color to Card containers

### DIFF
--- a/app/src/main/java/com/example/woof/MainActivity.kt
+++ b/app/src/main/java/com/example/woof/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -112,7 +113,10 @@ fun DogItem(
 ) {
     var expanded by remember { mutableStateOf(false) }
     Card(
-        modifier = modifier
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
Problem:
The Card component in DogItem was not applying theme colors, resulting in list items displaying different colors than the Google Developers codelab reference images.

Solution:
Added color configuration to the Card component by:
1. Importing CardDefaults from Material3
2. Setting the colors parameter with CardDefaults.cardColors()
3. Applying MaterialTheme.colorScheme.secondaryContainer as the container background color

| BEFORE CHANGES | AFTER CHANGES |
|---|---|
|<img width="622" height="686" alt="Screenshot 2025-12-01 at 14 39 31" src="https://github.com/user-attachments/assets/48e97059-9ad5-430c-a739-43c65b3c45b2" />|<img width="619" height="687" alt="Screenshot 2025-12-01 at 14 38 42" src="https://github.com/user-attachments/assets/17ee8fcc-a203-4f56-9727-be7c69da7e08" />|


